### PR TITLE
Fix incompatibilities with OpenSSL 1.0.x

### DIFF
--- a/nid.go
+++ b/nid.go
@@ -17,6 +17,7 @@ package openssl
 type NID int
 
 const (
+	NID_undef                              NID = 0
 	NID_rsadsi                             NID = 1
 	NID_pkcs                               NID = 2
 	NID_md2                                NID = 3
@@ -196,4 +197,10 @@ const (
 	NID_ad_OCSP                            NID = 178
 	NID_ad_ca_issuers                      NID = 179
 	NID_OCSP_sign                          NID = 180
+	NID_x9_62_id_ecPublicKey               NID = 408
+	NID_hmac                               NID = 855
+	NID_cmac                               NID = 894
+	NID_dhpublicnumber                     NID = 920
+	NID_tls1_prf                           NID = 1021
+	NID_hdkf                               NID = 1036
 )

--- a/shim.c
+++ b/shim.c
@@ -281,9 +281,29 @@ void X_HMAC_CTX_free(HMAC_CTX *ctx) {
 }
 
 int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u) {
-	// This method was renamed to PEM_write_bio_PrivateKey_traditional in
-	// v1.1.0
-	return PEM_write_bio_PrivateKey(bio, key, enc, kstr, klen, cb, u);
+	/* PEM_write_bio_PrivateKey always tries to use the PKCS8 format if it
+	 * is available, instead of using the "traditional" format as stated in the
+	 * OpenSSL man page.
+	 * i2d_PrivateKey should give us the correct DER encoding, so we'll just
+	 * use PEM_ASN1_write_bio directly to write the DER encoding with the correct
+	 * type header. */
+
+	int ppkey_id, pkey_base_id, ppkey_flags;
+	const char *pinfo, *ppem_str;
+	char pem_type_str[80];
+
+	// Lookup the ASN1 method information to get the pem type
+	if (EVP_PKEY_asn1_get0_info(&ppkey_id, &pkey_base_id, &ppkey_flags, &pinfo, &ppem_str, key->ameth) != 1) {
+		return 0;
+	}
+	// Set up the PEM type string
+	if (BIO_snprintf(pem_type_str, 80, "%s PRIVATE KEY", ppem_str) <= 0) {
+		// Failed to write out the pem type string, something is really wrong.
+		return 0;
+	}
+	// Write out everything to the BIO
+	return PEM_ASN1_write_bio((i2d_of_void *)i2d_PrivateKey,
+		pem_type_str, bio, key, enc, kstr, klen, cb, u);
 }
 
 #endif

--- a/shim.c
+++ b/shim.c
@@ -156,6 +156,10 @@ void X_HMAC_CTX_free(HMAC_CTX *ctx) {
 	HMAC_CTX_free(ctx);
 }
 
+int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u) {
+	return PEM_write_bio_PrivateKey_traditional(bio, key, enc, kstr, klen, cb, u);
+}
+
 #endif
 
 
@@ -274,6 +278,12 @@ void X_HMAC_CTX_free(HMAC_CTX *ctx) {
 		HMAC_CTX_cleanup(ctx);
 		OPENSSL_free(ctx);
 	}
+}
+
+int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u) {
+	// This method was renamed to PEM_write_bio_PrivateKey_traditional in
+	// v1.1.0
+	return PEM_write_bio_PrivateKey(bio, key, enc, kstr, klen, cb, u);
 }
 
 #endif

--- a/shim.h
+++ b/shim.h
@@ -158,3 +158,5 @@ extern const ASN1_TIME *X_X509_get0_notAfter(const X509 *x);
 extern int X_sk_X509_num(STACK_OF(X509) *sk);
 extern X509 *X_sk_X509_value(STACK_OF(X509)* sk, int i);
 
+/* PEM methods */
+extern int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u);


### PR DESCRIPTION
There were two main issues before preventing the bindings from compiling against OpenSSL 1.0.x:

- Two of the KeyType constants relied on defines added in OpenSSL v1.1.0
- The `PEM_write_bio_PrivateKey_traditional` function was added in OpenSSL v1.1.0.

This PR uses NID instead of KeyType, with the relevant NIDs added in to fix the constants issue.

Additionally, a shim function for `PEM_write_bio_PrivateKey_traditional` was added for OpenSSL < v1.1.0.